### PR TITLE
Use composite when drawing images

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -563,7 +563,9 @@ class Context {
                 var ty = j/dh;
                 var ssy = sy+Math.floor(ty * sh);
                 //var rgba = bitmap.getPixelRGBA(ssx,ssy);
-                var rgba = bitmap.getPixelRGBA_bilinear(sx+tx*sw,sy+ty*sh);
+                var fgRGBA = bitmap.getPixelRGBA_bilinear(sx+tx*sw,sy+ty*sh);
+                var bgRGBA = this.bitmap.getPixelRGBA_bilinear(dx+i, dy+j);
+                var rgba = this.composite(0, 0, bgRGBA, fgRGBA);
                 this.bitmap.setPixelRGBA(dx+i, dy+j, rgba);
             }
         }


### PR DESCRIPTION
Fixes bug when alpha from foreground image would overwrite alpha from background image

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Description
Added call to `composite` in `drawImage` to prevent copying alpha channel from foreground to background